### PR TITLE
Last trailer comment has priority

### DIFF
--- a/Tests/images/zero_bb_eof_before_boundingbox.eps
+++ b/Tests/images/zero_bb_eof_before_boundingbox.eps
@@ -1,0 +1,1494 @@
+%!PS-Adobe-2.0 EPSF-2.0
+%%Title: sample.eps
+%%Creator: gnuplot 4.6 patchlevel 3
+%%CreationDate: Wed Nov 20 00:23:10 2013
+%%DocumentFonts: (atend)
+%%BoundingBox: (atend)
+%%EndComments
+%%BeginProlog
+/gnudict 256 dict def
+gnudict begin
+%
+% The following true/false flags may be edited by hand if desired.
+% The unit line width and grayscale image gamma correction may also be changed.
+%
+/Color true def
+/Blacktext false def
+/Solid false def
+/Dashlength 1 def
+/Landscape false def
+/Level1 false def
+/Rounded false def
+/ClipToBoundingBox false def
+/SuppressPDFMark false def
+/TransparentPatterns false def
+/gnulinewidth 5.000 def
+/userlinewidth gnulinewidth def
+/Gamma 1.0 def
+/BackgroundColor {-1.000 -1.000 -1.000} def
+%
+/vshift -46 def
+/dl1 {
+  10.0 Dashlength mul mul
+  Rounded { currentlinewidth 0.75 mul sub dup 0 le { pop 0.01 } if } if
+} def
+/dl2 {
+  10.0 Dashlength mul mul
+  Rounded { currentlinewidth 0.75 mul add } if
+} def
+/hpt_ 31.5 def
+/vpt_ 31.5 def
+/hpt hpt_ def
+/vpt vpt_ def
+/doclip {
+  ClipToBoundingBox {
+    newpath 50 50 moveto 410 50 lineto 410 302 lineto 50 302 lineto closepath
+    clip
+  } if
+} def
+%
+% Gnuplot Prolog Version 4.6 (September 2012)
+%
+%/SuppressPDFMark true def
+%
+/M {moveto} bind def
+/L {lineto} bind def
+/R {rmoveto} bind def
+/V {rlineto} bind def
+/N {newpath moveto} bind def
+/Z {closepath} bind def
+/C {setrgbcolor} bind def
+/f {rlineto fill} bind def
+/g {setgray} bind def
+/Gshow {show} def   % May be redefined later in the file to support UTF-8
+/vpt2 vpt 2 mul def
+/hpt2 hpt 2 mul def
+/Lshow {currentpoint stroke M 0 vshift R
+	Blacktext {gsave 0 setgray show grestore} {show} ifelse} def
+/Rshow {currentpoint stroke M dup stringwidth pop neg vshift R
+	Blacktext {gsave 0 setgray show grestore} {show} ifelse} def
+/Cshow {currentpoint stroke M dup stringwidth pop -2 div vshift R
+	Blacktext {gsave 0 setgray show grestore} {show} ifelse} def
+/UP {dup vpt_ mul /vpt exch def hpt_ mul /hpt exch def
+  /hpt2 hpt 2 mul def /vpt2 vpt 2 mul def} def
+/DL {Color {setrgbcolor Solid {pop []} if 0 setdash}
+ {pop pop pop 0 setgray Solid {pop []} if 0 setdash} ifelse} def
+/BL {stroke userlinewidth 2 mul setlinewidth
+	Rounded {1 setlinejoin 1 setlinecap} if} def
+/AL {stroke userlinewidth 2 div setlinewidth
+	Rounded {1 setlinejoin 1 setlinecap} if} def
+/UL {dup gnulinewidth mul /userlinewidth exch def
+	dup 1 lt {pop 1} if 10 mul /udl exch def} def
+/PL {stroke userlinewidth setlinewidth
+	Rounded {1 setlinejoin 1 setlinecap} if} def
+3.8 setmiterlimit
+% Default Line colors
+/LCw {1 1 1} def
+/LCb {0 0 0} def
+/LCa {0 0 0} def
+/LC0 {1 0 0} def
+/LC1 {0 1 0} def
+/LC2 {0 0 1} def
+/LC3 {1 0 1} def
+/LC4 {0 1 1} def
+/LC5 {1 1 0} def
+/LC6 {0 0 0} def
+/LC7 {1 0.3 0} def
+/LC8 {0.5 0.5 0.5} def
+% Default Line Types
+/LTw {PL [] 1 setgray} def
+/LTb {BL [] LCb DL} def
+/LTa {AL [1 udl mul 2 udl mul] 0 setdash LCa setrgbcolor} def
+/LT0 {PL [] LC0 DL} def
+/LT1 {PL [4 dl1 2 dl2] LC1 DL} def
+/LT2 {PL [2 dl1 3 dl2] LC2 DL} def
+/LT3 {PL [1 dl1 1.5 dl2] LC3 DL} def
+/LT4 {PL [6 dl1 2 dl2 1 dl1 2 dl2] LC4 DL} def
+/LT5 {PL [3 dl1 3 dl2 1 dl1 3 dl2] LC5 DL} def
+/LT6 {PL [2 dl1 2 dl2 2 dl1 6 dl2] LC6 DL} def
+/LT7 {PL [1 dl1 2 dl2 6 dl1 2 dl2 1 dl1 2 dl2] LC7 DL} def
+/LT8 {PL [2 dl1 2 dl2 2 dl1 2 dl2 2 dl1 2 dl2 2 dl1 4 dl2] LC8 DL} def
+/Pnt {stroke [] 0 setdash gsave 1 setlinecap M 0 0 V stroke grestore} def
+/Dia {stroke [] 0 setdash 2 copy vpt add M
+  hpt neg vpt neg V hpt vpt neg V
+  hpt vpt V hpt neg vpt V closepath stroke
+  Pnt} def
+/Pls {stroke [] 0 setdash vpt sub M 0 vpt2 V
+  currentpoint stroke M
+  hpt neg vpt neg R hpt2 0 V stroke
+ } def
+/Box {stroke [] 0 setdash 2 copy exch hpt sub exch vpt add M
+  0 vpt2 neg V hpt2 0 V 0 vpt2 V
+  hpt2 neg 0 V closepath stroke
+  Pnt} def
+/Crs {stroke [] 0 setdash exch hpt sub exch vpt add M
+  hpt2 vpt2 neg V currentpoint stroke M
+  hpt2 neg 0 R hpt2 vpt2 V stroke} def
+/TriU {stroke [] 0 setdash 2 copy vpt 1.12 mul add M
+  hpt neg vpt -1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt 1.62 mul V closepath stroke
+  Pnt} def
+/Star {2 copy Pls Crs} def
+/BoxF {stroke [] 0 setdash exch hpt sub exch vpt add M
+  0 vpt2 neg V hpt2 0 V 0 vpt2 V
+  hpt2 neg 0 V closepath fill} def
+/TriUF {stroke [] 0 setdash vpt 1.12 mul add M
+  hpt neg vpt -1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt 1.62 mul V closepath fill} def
+/TriD {stroke [] 0 setdash 2 copy vpt 1.12 mul sub M
+  hpt neg vpt 1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt -1.62 mul V closepath stroke
+  Pnt} def
+/TriDF {stroke [] 0 setdash vpt 1.12 mul sub M
+  hpt neg vpt 1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt -1.62 mul V closepath fill} def
+/DiaF {stroke [] 0 setdash vpt add M
+  hpt neg vpt neg V hpt vpt neg V
+  hpt vpt V hpt neg vpt V closepath fill} def
+/Pent {stroke [] 0 setdash 2 copy gsave
+  translate 0 hpt M 4 {72 rotate 0 hpt L} repeat
+  closepath stroke grestore Pnt} def
+/PentF {stroke [] 0 setdash gsave
+  translate 0 hpt M 4 {72 rotate 0 hpt L} repeat
+  closepath fill grestore} def
+/Circle {stroke [] 0 setdash 2 copy
+  hpt 0 360 arc stroke Pnt} def
+/CircleF {stroke [] 0 setdash hpt 0 360 arc fill} def
+/C0 {BL [] 0 setdash 2 copy moveto vpt 90 450 arc} bind def
+/C1 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 90 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C2 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 90 180 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C3 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 180 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C4 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 180 270 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C5 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 90 arc
+	2 copy moveto
+	2 copy vpt 180 270 arc closepath fill
+	vpt 0 360 arc} bind def
+/C6 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 90 270 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C7 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 270 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C8 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 270 360 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C9 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 270 450 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C10 {BL [] 0 setdash 2 copy 2 copy moveto vpt 270 360 arc closepath fill
+	2 copy moveto
+	2 copy vpt 90 180 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C11 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 180 arc closepath fill
+	2 copy moveto
+	2 copy vpt 270 360 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C12 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 180 360 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C13 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 0 90 arc closepath fill
+	2 copy moveto
+	2 copy vpt 180 360 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/C14 {BL [] 0 setdash 2 copy moveto
+	2 copy vpt 90 360 arc closepath fill
+	vpt 0 360 arc} bind def
+/C15 {BL [] 0 setdash 2 copy vpt 0 360 arc closepath fill
+	vpt 0 360 arc closepath} bind def
+/Rec {newpath 4 2 roll moveto 1 index 0 rlineto 0 exch rlineto
+	neg 0 rlineto closepath} bind def
+/Square {dup Rec} bind def
+/Bsquare {vpt sub exch vpt sub exch vpt2 Square} bind def
+/S0 {BL [] 0 setdash 2 copy moveto 0 vpt rlineto BL Bsquare} bind def
+/S1 {BL [] 0 setdash 2 copy vpt Square fill Bsquare} bind def
+/S2 {BL [] 0 setdash 2 copy exch vpt sub exch vpt Square fill Bsquare} bind def
+/S3 {BL [] 0 setdash 2 copy exch vpt sub exch vpt2 vpt Rec fill Bsquare} bind def
+/S4 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt Square fill Bsquare} bind def
+/S5 {BL [] 0 setdash 2 copy 2 copy vpt Square fill
+	exch vpt sub exch vpt sub vpt Square fill Bsquare} bind def
+/S6 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt vpt2 Rec fill Bsquare} bind def
+/S7 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt vpt2 Rec fill
+	2 copy vpt Square fill Bsquare} bind def
+/S8 {BL [] 0 setdash 2 copy vpt sub vpt Square fill Bsquare} bind def
+/S9 {BL [] 0 setdash 2 copy vpt sub vpt vpt2 Rec fill Bsquare} bind def
+/S10 {BL [] 0 setdash 2 copy vpt sub vpt Square fill 2 copy exch vpt sub exch vpt Square fill
+	Bsquare} bind def
+/S11 {BL [] 0 setdash 2 copy vpt sub vpt Square fill 2 copy exch vpt sub exch vpt2 vpt Rec fill
+	Bsquare} bind def
+/S12 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt2 vpt Rec fill Bsquare} bind def
+/S13 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt2 vpt Rec fill
+	2 copy vpt Square fill Bsquare} bind def
+/S14 {BL [] 0 setdash 2 copy exch vpt sub exch vpt sub vpt2 vpt Rec fill
+	2 copy exch vpt sub exch vpt Square fill Bsquare} bind def
+/S15 {BL [] 0 setdash 2 copy Bsquare fill Bsquare} bind def
+/D0 {gsave translate 45 rotate 0 0 S0 stroke grestore} bind def
+/D1 {gsave translate 45 rotate 0 0 S1 stroke grestore} bind def
+/D2 {gsave translate 45 rotate 0 0 S2 stroke grestore} bind def
+/D3 {gsave translate 45 rotate 0 0 S3 stroke grestore} bind def
+/D4 {gsave translate 45 rotate 0 0 S4 stroke grestore} bind def
+/D5 {gsave translate 45 rotate 0 0 S5 stroke grestore} bind def
+/D6 {gsave translate 45 rotate 0 0 S6 stroke grestore} bind def
+/D7 {gsave translate 45 rotate 0 0 S7 stroke grestore} bind def
+/D8 {gsave translate 45 rotate 0 0 S8 stroke grestore} bind def
+/D9 {gsave translate 45 rotate 0 0 S9 stroke grestore} bind def
+/D10 {gsave translate 45 rotate 0 0 S10 stroke grestore} bind def
+/D11 {gsave translate 45 rotate 0 0 S11 stroke grestore} bind def
+/D12 {gsave translate 45 rotate 0 0 S12 stroke grestore} bind def
+/D13 {gsave translate 45 rotate 0 0 S13 stroke grestore} bind def
+/D14 {gsave translate 45 rotate 0 0 S14 stroke grestore} bind def
+/D15 {gsave translate 45 rotate 0 0 S15 stroke grestore} bind def
+/DiaE {stroke [] 0 setdash vpt add M
+  hpt neg vpt neg V hpt vpt neg V
+  hpt vpt V hpt neg vpt V closepath stroke} def
+/BoxE {stroke [] 0 setdash exch hpt sub exch vpt add M
+  0 vpt2 neg V hpt2 0 V 0 vpt2 V
+  hpt2 neg 0 V closepath stroke} def
+/TriUE {stroke [] 0 setdash vpt 1.12 mul add M
+  hpt neg vpt -1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt 1.62 mul V closepath stroke} def
+/TriDE {stroke [] 0 setdash vpt 1.12 mul sub M
+  hpt neg vpt 1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt -1.62 mul V closepath stroke} def
+/PentE {stroke [] 0 setdash gsave
+  translate 0 hpt M 4 {72 rotate 0 hpt L} repeat
+  closepath stroke grestore} def
+/CircE {stroke [] 0 setdash
+  hpt 0 360 arc stroke} def
+/Opaque {gsave closepath 1 setgray fill grestore 0 setgray closepath} def
+/DiaW {stroke [] 0 setdash vpt add M
+  hpt neg vpt neg V hpt vpt neg V
+  hpt vpt V hpt neg vpt V Opaque stroke} def
+/BoxW {stroke [] 0 setdash exch hpt sub exch vpt add M
+  0 vpt2 neg V hpt2 0 V 0 vpt2 V
+  hpt2 neg 0 V Opaque stroke} def
+/TriUW {stroke [] 0 setdash vpt 1.12 mul add M
+  hpt neg vpt -1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt 1.62 mul V Opaque stroke} def
+/TriDW {stroke [] 0 setdash vpt 1.12 mul sub M
+  hpt neg vpt 1.62 mul V
+  hpt 2 mul 0 V
+  hpt neg vpt -1.62 mul V Opaque stroke} def
+/PentW {stroke [] 0 setdash gsave
+  translate 0 hpt M 4 {72 rotate 0 hpt L} repeat
+  Opaque stroke grestore} def
+/CircW {stroke [] 0 setdash
+  hpt 0 360 arc Opaque stroke} def
+/BoxFill {gsave Rec 1 setgray fill grestore} def
+/Density {
+  /Fillden exch def
+  currentrgbcolor
+  /ColB exch def /ColG exch def /ColR exch def
+  /ColR ColR Fillden mul Fillden sub 1 add def
+  /ColG ColG Fillden mul Fillden sub 1 add def
+  /ColB ColB Fillden mul Fillden sub 1 add def
+  ColR ColG ColB setrgbcolor} def
+/BoxColFill {gsave Rec PolyFill} def
+/PolyFill {gsave Density fill grestore grestore} def
+/h {rlineto rlineto rlineto gsave closepath fill grestore} bind def
+%
+% PostScript Level 1 Pattern Fill routine for rectangles
+% Usage: x y w h s a XX PatternFill
+%	x,y = lower left corner of box to be filled
+%	w,h = width and height of box
+%	  a = angle in degrees between lines and x-axis
+%	 XX = 0/1 for no/yes cross-hatch
+%
+/PatternFill {gsave /PFa [ 9 2 roll ] def
+  PFa 0 get PFa 2 get 2 div add PFa 1 get PFa 3 get 2 div add translate
+  PFa 2 get -2 div PFa 3 get -2 div PFa 2 get PFa 3 get Rec
+  TransparentPatterns {} {gsave 1 setgray fill grestore} ifelse
+  clip
+  currentlinewidth 0.5 mul setlinewidth
+  /PFs PFa 2 get dup mul PFa 3 get dup mul add sqrt def
+  0 0 M PFa 5 get rotate PFs -2 div dup translate
+  0 1 PFs PFa 4 get div 1 add floor cvi
+	{PFa 4 get mul 0 M 0 PFs V} for
+  0 PFa 6 get ne {
+	0 1 PFs PFa 4 get div 1 add floor cvi
+	{PFa 4 get mul 0 2 1 roll M PFs 0 V} for
+ } if
+  stroke grestore} def
+%
+/languagelevel where
+ {pop languagelevel} {1} ifelse
+ 2 lt
+	{/InterpretLevel1 true def}
+	{/InterpretLevel1 Level1 def}
+ ifelse
+%
+% PostScript level 2 pattern fill definitions
+%
+/Level2PatternFill {
+/Tile8x8 {/PaintType 2 /PatternType 1 /TilingType 1 /BBox [0 0 8 8] /XStep 8 /YStep 8}
+	bind def
+/KeepColor {currentrgbcolor [/Pattern /DeviceRGB] setcolorspace} bind def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop 0 0 M 8 8 L 0 8 M 8 0 L stroke}
+>> matrix makepattern
+/Pat1 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop 0 0 M 8 8 L 0 8 M 8 0 L stroke
+	0 4 M 4 8 L 8 4 L 4 0 L 0 4 L stroke}
+>> matrix makepattern
+/Pat2 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop 0 0 M 0 8 L
+	8 8 L 8 0 L 0 0 L fill}
+>> matrix makepattern
+/Pat3 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop -4 8 M 8 -4 L
+	0 12 M 12 0 L stroke}
+>> matrix makepattern
+/Pat4 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop -4 0 M 8 12 L
+	0 -4 M 12 8 L stroke}
+>> matrix makepattern
+/Pat5 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop -2 8 M 4 -4 L
+	0 12 M 8 -4 L 4 12 M 10 0 L stroke}
+>> matrix makepattern
+/Pat6 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop -2 0 M 4 12 L
+	0 -4 M 8 12 L 4 -4 M 10 8 L stroke}
+>> matrix makepattern
+/Pat7 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop 8 -2 M -4 4 L
+	12 0 M -4 8 L 12 4 M 0 10 L stroke}
+>> matrix makepattern
+/Pat8 exch def
+<< Tile8x8
+ /PaintProc {0.5 setlinewidth pop 0 -2 M 12 4 L
+	-4 0 M 12 8 L -4 4 M 8 10 L stroke}
+>> matrix makepattern
+/Pat9 exch def
+/Pattern1 {PatternBgnd KeepColor Pat1 setpattern} bind def
+/Pattern2 {PatternBgnd KeepColor Pat2 setpattern} bind def
+/Pattern3 {PatternBgnd KeepColor Pat3 setpattern} bind def
+/Pattern4 {PatternBgnd KeepColor Landscape {Pat5} {Pat4} ifelse setpattern} bind def
+/Pattern5 {PatternBgnd KeepColor Landscape {Pat4} {Pat5} ifelse setpattern} bind def
+/Pattern6 {PatternBgnd KeepColor Landscape {Pat9} {Pat6} ifelse setpattern} bind def
+/Pattern7 {PatternBgnd KeepColor Landscape {Pat8} {Pat7} ifelse setpattern} bind def
+} def
+%
+%
+%End of PostScript Level 2 code
+%
+/PatternBgnd {
+  TransparentPatterns {} {gsave 1 setgray fill grestore} ifelse
+} def
+%
+% Substitute for Level 2 pattern fill codes with
+% grayscale if Level 2 support is not selected.
+%
+/Level1PatternFill {
+/Pattern1 {0.250 Density} bind def
+/Pattern2 {0.500 Density} bind def
+/Pattern3 {0.750 Density} bind def
+/Pattern4 {0.125 Density} bind def
+/Pattern5 {0.375 Density} bind def
+/Pattern6 {0.625 Density} bind def
+/Pattern7 {0.875 Density} bind def
+} def
+%
+% Now test for support of Level 2 code
+%
+Level1 {Level1PatternFill} {Level2PatternFill} ifelse
+%
+/Symbol-Oblique /Symbol findfont [1 0 .167 1 0 0] makefont
+dup length dict begin {1 index /FID eq {pop pop} {def} ifelse} forall
+currentdict end definefont pop
+Level1 SuppressPDFMark or
+{} {
+/SDict 10 dict def
+systemdict /pdfmark known not {
+  userdict /pdfmark systemdict /cleartomark get put
+} if
+SDict begin [
+  /Title (sample.eps)
+  /Subject (gnuplot plot)
+  /Creator (gnuplot 4.6 patchlevel 3)
+  /Author (mentalpower)
+%  /Producer (gnuplot)
+%  /Keywords ()
+  /CreationDate (Wed Nov 20 00:23:10 2013)
+  /DOCINFO pdfmark
+end
+} ifelse
+end
+%%EndProlog
+%%Page: 1 1
+gnudict begin
+gsave
+doclip
+50 50 translate
+0.050 0.050 scale
+0 setgray
+newpath
+(Helvetica) findfont 140 scalefont setfont
+BackgroundColor 0 lt 3 1 roll 0 lt exch 0 lt or or not {BackgroundColor C 1.000 0 0 7200.00 5040.00 BoxColFill} if
+1.000 UL
+LTb
+LCb setrgbcolor
+LTb
+3600 4773 M
+(Interlocking Tori) Cshow
+1.000 UP
+% Begin plot #1
+1.000 UL
+LT0
+LC0 setrgbcolor
+3896 3541 M
+-104 38 V
+stroke
+LT0
+LC0 setrgbcolor
+3685 3502 M
+107 77 V
+stroke
+LT0
+LC0 setrgbcolor
+2901 3533 M
+891 46 V
+stroke
+LT0
+LC0 setrgbcolor
+2142 3242 M
+759 291 V
+stroke
+LT0
+LC0 setrgbcolor
+2977 3427 M
+-76 106 V
+stroke
+LT0
+LC3 setrgbcolor
+4293 2350 M
+-21 2 V
+stroke
+LT0
+LC0 setrgbcolor
+2977 3427 M
+425 22 V
+stroke
+LT0
+LC0 setrgbcolor
+1639 2658 M
+320 470 V
+stroke
+LT0
+LC1 setrgbcolor
+2142 3242 M
+1959 3128 L
+stroke
+LT0
+LC0 setrgbcolor
+2142 3242 M
+1959 3128 L
+stroke
+LT0
+LC3 setrgbcolor
+3569 1853 M
+-11 -160 V
+stroke
+LT0
+LC3 setrgbcolor
+3159 1946 M
+399 -253 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 1624 M
+-701 69 V
+stroke
+LT0
+LC0 setrgbcolor
+3017 3294 M
+-40 133 V
+stroke
+LT0
+LC0 setrgbcolor
+2423 3214 M
+554 213 V
+stroke
+LT0
+LC0 setrgbcolor
+3887 2095 M
+406 272 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 1624 M
+260 -20 V
+stroke
+LT0
+LC3 setrgbcolor
+5058 1939 M
+4519 1604 L
+stroke
+LT0
+LC0 setrgbcolor
+2669 3058 M
+234 89 V
+stroke
+LT0
+LC0 setrgbcolor
+2669 3058 M
+81 -175 V
+stroke
+LT0
+LC0 setrgbcolor
+2683 2722 M
+3 5 V
+stroke
+LT0
+LC0 setrgbcolor
+2683 2722 M
+3 5 V
+stroke
+LT0
+LC0 setrgbcolor
+2669 3058 M
+81 -175 V
+stroke
+LT0
+LC0 setrgbcolor
+2423 3214 M
+-281 28 V
+stroke
+LT0
+LC0 setrgbcolor
+1870 2842 M
+272 400 V
+stroke
+LT0
+LC0 setrgbcolor
+2423 3214 M
+-281 28 V
+stroke
+LT0
+LC3 setrgbcolor
+4225 2265 M
+-73 7 V
+stroke
+LT0
+LC3 setrgbcolor
+4225 2265 M
+-73 7 V
+stroke
+LT0
+LC0 setrgbcolor
+4011 2179 M
+282 189 V
+stroke
+LT0
+LC3 setrgbcolor
+2687 2718 M
+-1 9 V
+stroke
+LT0
+LC2 setrgbcolor
+2687 2718 M
+-1 9 V
+stroke
+LT0
+LC3 setrgbcolor
+2969 3262 M
+2696 2790 L
+stroke
+LT0
+LC3 setrgbcolor
+3699 2056 M
+3569 1853 L
+stroke
+LT0
+LC3 setrgbcolor
+3358 1986 M
+211 -133 V
+stroke
+LT0
+LC3 setrgbcolor
+4081 1802 M
+-512 51 V
+stroke
+LT0
+LC0 setrgbcolor
+2423 3214 M
+246 -156 V
+stroke
+LT0
+LC0 setrgbcolor
+2423 3214 M
+246 -156 V
+stroke
+LT0
+LC0 setrgbcolor
+2535 2860 M
+134 198 V
+stroke
+LT0
+LC0 setrgbcolor
+2224 2922 M
+199 292 V
+stroke
+LT0
+LC3 setrgbcolor
+4718 1909 M
+4259 1624 L
+stroke
+LT0
+LC3 setrgbcolor
+4081 1802 M
+178 -178 V
+stroke
+LT0
+LC3 setrgbcolor
+4067 2055 M
+-251 25 V
+stroke
+LT0
+LC3 setrgbcolor
+4067 2055 M
+158 210 V
+stroke
+LT0
+LC3 setrgbcolor
+4293 2307 M
+-68 -42 V
+stroke
+LT0
+LC2 setrgbcolor
+4293 2307 M
+-68 -42 V
+stroke
+LT0
+LC0 setrgbcolor
+4011 2381 M
+211 141 V
+stroke
+LT0
+LC0 setrgbcolor
+2042 2077 M
+-403 379 V
+stroke
+LT0
+LC0 setrgbcolor
+1639 2658 M
+0 -202 V
+stroke
+LT0
+LC3 setrgbcolor
+2941 3034 M
+2746 2697 L
+stroke
+LT0
+LC0 setrgbcolor
+3532 2744 M
+58 39 V
+stroke
+LT0
+LC3 setrgbcolor
+4067 2055 M
+14 -253 V
+stroke
+LT0
+LC3 setrgbcolor
+4416 2011 M
+4081 1802 L
+stroke
+LT0
+LC3 setrgbcolor
+4293 2196 M
+4067 2055 L
+stroke
+LT0
+LC3 setrgbcolor
+5277 2680 M
+0 -594 V
+stroke
+LT0
+LC3 setrgbcolor
+5058 1939 M
+219 147 V
+stroke
+LT0
+LC3 setrgbcolor
+3417 2751 M
+-21 -36 V
+stroke
+LT0
+LC0 setrgbcolor
+3887 2607 M
+141 94 V
+stroke
+LT0
+LC0 setrgbcolor
+2705 2701 M
+-170 159 V
+stroke
+LT0
+LC0 setrgbcolor
+2224 2922 M
+311 -62 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 1915 M
+877 180 V
+stroke
+LT0
+LC0 setrgbcolor
+4011 2179 M
+-124 -84 V
+stroke
+LT0
+LC3 setrgbcolor
+3118 2832 M
+-97 -167 V
+stroke
+LT0
+LC0 setrgbcolor
+3698 2750 M
+64 43 V
+stroke
+LT0
+LC0 setrgbcolor
+1870 2842 M
+1639 2658 L
+stroke
+LT0
+LC0 setrgbcolor
+2042 2280 M
+-403 378 V
+stroke
+LT0
+LC3 setrgbcolor
+3913 3544 M
+3188 3409 L
+stroke
+LT0
+LC3 setrgbcolor
+2969 3262 M
+219 147 V
+stroke
+LT0
+LC3 setrgbcolor
+4718 1909 M
+340 30 V
+stroke
+LT0
+LC3 setrgbcolor
+5058 2534 M
+0 -595 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 1915 M
+-797 93 V
+stroke
+LT0
+LC0 setrgbcolor
+2042 2077 M
+171 -69 V
+stroke
+LT0
+LC0 setrgbcolor
+1870 2842 M
+354 80 V
+stroke
+LT0
+LC0 setrgbcolor
+2474 2687 M
+-250 235 V
+stroke
+LT0
+LC0 setrgbcolor
+3698 2750 M
+-166 -6 V
+stroke
+LT0
+LC0 setrgbcolor
+3420 2721 M
+112 23 V
+stroke
+LT0
+LC0 setrgbcolor
+3098 2657 M
+266 53 V
+stroke
+LT0
+LC3 setrgbcolor
+4293 2446 M
+0 -250 V
+stroke
+LT0
+LC3 setrgbcolor
+4416 2011 M
+-123 185 V
+stroke
+LT0
+LC0 setrgbcolor
+2213 2521 M
+-343 321 V
+stroke
+LT0
+LC0 setrgbcolor
+3098 2657 M
+-393 44 V
+stroke
+LT0
+LC0 setrgbcolor
+2474 2687 M
+231 14 V
+stroke
+LT0
+LC3 setrgbcolor
+5277 2680 M
+-4 107 V
+stroke
+LT0
+LC3 setrgbcolor
+4815 3277 M
+458 -490 V
+stroke
+LT0
+LC0 setrgbcolor
+2980 1968 M
+30 -53 V
+stroke
+LT0
+LC3 setrgbcolor
+3721 2808 M
+-304 -57 V
+stroke
+LT0
+LC3 setrgbcolor
+3118 2832 M
+299 -81 V
+stroke
+LT0
+LC0 setrgbcolor
+4011 2381 M
+0 -202 V
+stroke
+LT0
+LC0 setrgbcolor
+2980 1968 M
+1031 211 V
+stroke
+LT0
+LC3 setrgbcolor
+4416 2011 M
+302 -102 V
+stroke
+LT0
+LC3 setrgbcolor
+4718 2415 M
+0 -506 V
+stroke
+LT0
+LC0 setrgbcolor
+3057 2620 M
+41 37 V
+stroke
+LT0
+LC3 setrgbcolor
+4416 2381 M
+0 -370 V
+stroke
+LT0
+LC3 setrgbcolor
+2941 3034 M
+28 228 V
+stroke
+LT0
+LC3 setrgbcolor
+3694 3397 M
+2969 3262 L
+stroke
+LT0
+LC3 setrgbcolor
+4815 3277 M
+-702 245 V
+stroke
+LT0
+LC3 setrgbcolor
+3913 3544 M
+200 -22 V
+stroke
+LT0
+LC0 setrgbcolor
+3887 2607 M
+-189 143 V
+stroke
+LT0
+LC0 setrgbcolor
+3057 2620 M
+641 130 V
+stroke
+LT0
+LC0 setrgbcolor
+2980 1968 M
+-938 109 V
+stroke
+LT0
+LC0 setrgbcolor
+2042 2280 M
+0 -203 V
+stroke
+LT0
+LC3 setrgbcolor
+2941 3034 M
+177 -202 V
+stroke
+LT0
+LC3 setrgbcolor
+3569 2916 M
+-451 -84 V
+stroke
+LT0
+LC3 setrgbcolor
+4067 2687 M
+226 -241 V
+stroke
+LT0
+LC3 setrgbcolor
+4416 2381 M
+-123 65 V
+stroke
+LT0
+LC3 setrgbcolor
+3558 3149 M
+2941 3034 L
+stroke
+LT0
+LC0 setrgbcolor
+3887 2607 M
+124 -226 V
+stroke
+LT0
+LC0 setrgbcolor
+2980 2170 M
+1031 211 V
+stroke
+LT0
+LC3 setrgbcolor
+4067 2687 M
+-346 121 V
+stroke
+LT0
+LC3 setrgbcolor
+3569 2916 M
+152 -108 V
+stroke
+LT0
+LC0 setrgbcolor
+3057 2620 M
+-583 67 V
+stroke
+LT0
+LC0 setrgbcolor
+2213 2521 M
+261 166 V
+stroke
+LT0
+LC3 setrgbcolor
+4739 3256 M
+76 21 V
+stroke
+LT0
+LC3 setrgbcolor
+4739 3256 M
+538 -576 V
+stroke
+LT0
+LC3 setrgbcolor
+5058 2534 M
+219 146 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 2428 M
+877 179 V
+stroke
+LT0
+LC3 setrgbcolor
+4081 2738 M
+-14 -51 V
+stroke
+LT0
+LC0 setrgbcolor
+2980 2170 M
+0 -202 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 2428 M
+47 192 V
+stroke
+LT0
+LC0 setrgbcolor
+2213 2521 M
+2042 2280 L
+stroke
+LT0
+LC0 setrgbcolor
+2980 2170 M
+-938 110 V
+stroke
+LT0
+LC3 setrgbcolor
+3694 3397 M
+219 147 V
+stroke
+LT0
+LC3 setrgbcolor
+4739 3256 M
+-826 288 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 2428 M
+-797 93 V
+stroke
+LT0
+LC3 setrgbcolor
+4718 2415 M
+-302 -34 V
+stroke
+LT0
+LC3 setrgbcolor
+4081 2738 M
+335 -357 V
+stroke
+LT0
+LC3 setrgbcolor
+4718 2415 M
+340 119 V
+stroke
+LT0
+LC3 setrgbcolor
+4519 3109 M
+539 -575 V
+stroke
+LT0
+LC3 setrgbcolor
+4081 2738 M
+-512 178 V
+stroke
+LT0
+LC3 setrgbcolor
+3558 3149 M
+11 -233 V
+stroke
+LT0
+LC0 setrgbcolor
+3010 2428 M
+-30 -258 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 2904 M
+459 -489 V
+stroke
+LT0
+LC3 setrgbcolor
+4519 3109 M
+220 147 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 2904 M
+4081 2738 L
+stroke
+LT0
+LC3 setrgbcolor
+3558 3149 M
+136 248 V
+stroke
+LT0
+LC3 setrgbcolor
+4519 3109 M
+-825 288 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 2904 M
+-701 245 V
+stroke
+LT0
+LC3 setrgbcolor
+4259 2904 M
+260 205 V
+% End plot #1
+% Begin plot #2
+stroke
+LCb setrgbcolor
+/Helvetica findfont 140 scalefont setfont
+/vshift -46 def
+5692 490 M
+(cos\(u\)+.5*cos\(u\)*cos\(v\),sin\(u\)+.5*sin\(u\)*cos\(v\),.5*sin\(v\)) Rshow
+1.000 UL
+LT0
+1.00 0.00 0.00 C 1.00 0.00 0.00 C 5776 490 M
+399 0 V
+% End plot #2
+% Begin plot #3
+stroke
+LCb setrgbcolor
+/Helvetica findfont 140 scalefont setfont
+5692 350 M
+(1+cos\(u\)+.5*cos\(u\)*cos\(v\),.5*sin\(v\),sin\(u\)+.5*sin\(u\)*cos\(v\)) Rshow
+1.000 UL
+LT0
+0.00 0.00 1.00 C 0.00 0.00 1.00 C 5776 350 M
+399 0 V
+% End plot #3
+stroke
+LTb
+LCb setrgbcolor
+4304 755 M
+6229 2045 L
+stroke
+LTb
+LCb setrgbcolor
+4304 755 M
+971 1500 L
+stroke
+LTb
+LCb setrgbcolor
+971 1500 M
+984 659 V
+stroke
+LTb
+LCb setrgbcolor
+6229 2045 M
+-952 213 V
+stroke
+LTb
+LCb setrgbcolor
+971 3275 M
+0 -1775 V
+stroke
+LTb
+LCb setrgbcolor
+971 1500 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+901 1422 M
+(-1.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1388 1407 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+1318 1329 M
+(-1) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1804 1314 M
+53 35 V
+stroke
+LTb
+LCb setrgbcolor
+1735 1236 M
+(-0.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+2221 1221 M
+53 35 V
+stroke
+LTb
+LCb setrgbcolor
+2151 1143 M
+( 0) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+2638 1127 M
+52 36 V
+stroke
+LTb
+LCb setrgbcolor
+2568 1050 M
+( 0.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+3055 1034 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+2985 956 M
+( 1) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+3472 941 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+3402 863 M
+( 1.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+5343 2197 M
+53 35 V
+stroke
+LTb
+LCb setrgbcolor
+3887 848 M
+53 35 V
+stroke
+LTb
+LCb setrgbcolor
+3818 770 M
+( 2) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+5760 2103 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+4304 755 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+4234 677 M
+( 2.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+6177 2010 M
+52 35 V
+stroke
+LTb
+LCb setrgbcolor
+4304 755 M
+-54 12 V
+127 -39 R
+(-1.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1025 1488 M
+-54 12 V
+stroke
+LTb
+LCb setrgbcolor
+4625 970 M
+-55 12 V
+128 -39 R
+(-1) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1346 1703 M
+-54 12 V
+stroke
+LTb
+LCb setrgbcolor
+4946 1185 M
+-55 12 V
+128 -39 R
+(-0.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1667 1918 M
+-54 12 V
+stroke
+LTb
+LCb setrgbcolor
+5267 1400 M
+-55 12 V
+127 -39 R
+( 0) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1981 2134 M
+-48 11 V
+stroke
+LTb
+LCb setrgbcolor
+5587 1615 M
+-54 12 V
+127 -39 R
+( 0.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+5908 1830 M
+-54 12 V
+127 -39 R
+( 1) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+6229 2045 M
+-54 13 V
+127 -40 R
+( 1.5) Cshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 1500 M
+-63 0 V
+-126 0 R
+(-1.5) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 1796 M
+-63 0 V
+-126 0 R
+(-1) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 2092 M
+-63 0 V
+-126 0 R
+(-0.5) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 2388 M
+-63 0 V
+-126 0 R
+( 0) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 2683 M
+-63 0 V
+-126 0 R
+( 0.5) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 2979 M
+-63 0 V
+-126 0 R
+( 1) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UL
+LTb
+LCb setrgbcolor
+1034 3275 M
+-63 0 V
+-126 0 R
+( 1.5) Rshow
+1.000 UL
+LTb
+LCb setrgbcolor
+1.000 UP
+stroke
+grestore
+end
+showpage
+%%Trailer
+%%DocumentFonts: Helvetica
+%%EOF
+%%BoundingBox: 0 0 460 352

--- a/Tests/images/zero_bb_trailer.eps
+++ b/Tests/images/zero_bb_trailer.eps
@@ -1489,5 +1489,6 @@ grestore
 end
 showpage
 %%Trailer
+%%BoundingBox: 0 0 400 300
 %%BoundingBox: 0 0 460 352
 %%DocumentFonts: Helvetica

--- a/Tests/test_file_eps.py
+++ b/Tests/test_file_eps.py
@@ -406,10 +406,16 @@ def test_timeout(test_file):
                 pass
 
 
-def test_boundary_box_in_trailer():
-    # Check whether boundary boxes are parsed in the same way
-    # when specified in the header or the trailer
+def test_bounding_box_in_trailer():
+    # Check bounding boxes are parsed in the same way
+    # when specified in the header and the trailer
     with Image.open("Tests/images/zero_bb_trailer.eps") as trailer_image, Image.open(
         FILE1
     ) as header_image:
         assert trailer_image.size == header_image.size
+
+
+def test_eof_before_bounding_box():
+    with pytest.raises(OSError):
+        with Image.open("Tests/images/zero_bb_eof_before_boundingbox.eps"):
+            pass

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -373,8 +373,7 @@ class EpsImageFile(ImageFile.ImageFile):
 
                 s = str(bytes_mv[:bytes_read], "latin-1")
                 _read_comment(s)
-
-            if bytes_mv[:9] == b"%%Trailer":
+            elif bytes_mv[:9] == b"%%Trailer":
                 trailer_reached = True
             bytes_read = 0
 

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -245,6 +245,34 @@ class EpsImageFile(ImageFile.ImageFile):
                 msg = 'EPS header missing "%%BoundingBox" comment'
                 raise SyntaxError(msg)
 
+        def _read_comment(s):
+            nonlocal reading_trailer_comments
+            try:
+                m = split.match(s)
+            except re.error as e:
+                msg = "not an EPS file"
+                raise SyntaxError(msg) from e
+
+            if m:
+                k, v = m.group(1, 2)
+                self.info[k] = v
+                if k == "BoundingBox":
+                    if v == "(atend)":
+                        reading_trailer_comments = True
+                    elif not self._size:
+                        try:
+                            # Note: The DSC spec says that BoundingBox
+                            # fields should be integers, but some drivers
+                            # put floating point values there anyway.
+                            box = [int(float(i)) for i in v.split()]
+                            self._size = box[2] - box[0], box[3] - box[1]
+                            self.tile = [
+                                ("eps", (0, 0) + self.size, offset, (length, box))
+                            ]
+                        except Exception:
+                            pass
+                return True
+
         while True:
             byte = self.fp.read(1)
             if byte == b"":
@@ -289,22 +317,7 @@ class EpsImageFile(ImageFile.ImageFile):
                     continue
 
                 s = str(bytes_mv[:bytes_read], "latin-1")
-
-                try:
-                    m = split.match(s)
-                except re.error as e:
-                    msg = "not an EPS file"
-                    raise SyntaxError(msg) from e
-
-                if m:
-                    k, v = m.group(1, 2)
-                    self.info[k] = v
-                    if k == "BoundingBox":
-                        if v == "(atend)":
-                            reading_trailer_comments = True
-                        else:
-                            self._read_boundary_box(v, offset, length)
-                else:
+                if not _read_comment(s):
                     m = field.match(s)
                     if m:
                         k = m.group(1)
@@ -360,19 +373,7 @@ class EpsImageFile(ImageFile.ImageFile):
                     continue
 
                 s = str(bytes_mv[:bytes_read], "latin-1")
-
-                try:
-                    m = split.match(s)
-                except re.error as e:
-                    msg = "not an EPS file"
-                    raise SyntaxError(msg) from e
-
-                if m:
-                    k, v = m.group(1, 2)
-                    self.info[k] = v
-                    if k == "BoundingBox":
-                        if not self._size:
-                            self._read_boundary_box(v, offset, length)
+                _read_comment(s)
 
             if bytes_mv[:9] == b"%%Trailer":
                 trailer_reached = True
@@ -406,17 +407,6 @@ class EpsImageFile(ImageFile.ImageFile):
             raise SyntaxError(msg)
 
         return length, offset
-
-    def _read_boundary_box(self, v, offset, length):
-        try:
-            # Note: The DSC spec says that BoundingBox
-            # fields should be integers, but some drivers
-            # put floating point values there anyway.
-            box = [int(float(i)) for i in v.split()]
-            self._size = box[2] - box[0], box[3] - box[1]
-            self.tile = [("eps", (0, 0) + self.size, offset, (length, box))]
-        except Exception:
-            pass
 
     def load(self, scale=1, transparency=False):
         # Load EPS via Ghostscript

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -259,7 +259,7 @@ class EpsImageFile(ImageFile.ImageFile):
                 if k == "BoundingBox":
                     if v == "(atend)":
                         reading_trailer_comments = True
-                    elif not self._size:
+                    elif not self._size or reading_trailer_comments:
                         try:
                             # Note: The DSC spec says that BoundingBox
                             # fields should be integers, but some drivers

--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -367,10 +367,9 @@ class EpsImageFile(ImageFile.ImageFile):
                 # Load EPS trailer
 
                 # if this line starts with "%%EOF",
-                # then we've reached the end of the trailer
+                # then we've reached the end of the file
                 if bytes_mv[:5] == b"%%EOF":
-                    reading_trailer_comments = False
-                    continue
+                    break
 
                 s = str(bytes_mv[:bytes_read], "latin-1")
                 _read_comment(s)


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7382

- Group together some code to reduce duplication
- Break after reading "%%EOF"
- I found in https://web.mit.edu/PostScript/Adobe/Documents/5001.DSC_Spec.pdf under 4.4 that
> In the case of multiple trailer comments (those comments that were deferred using the (atend) convention), the last comment encountered is considered to be the truth.

so I've altered the code to use the size from the last BoundingBox in the trailer.